### PR TITLE
Exposing BSON constructors

### DIFF
--- a/index.js
+++ b/index.js
@@ -197,6 +197,15 @@ exports.connect = function(url, collections) {
 		function(next) {
 			var client = new mongo.Db(url.db, new mongo.Server(url.host, url.port), {native_parser:true});
 			
+			that.bson = {
+				Long:      client.bson_serializer.Long,
+				ObjectID:  client.bson_serializer.ObjectID,
+				Timestamp: client.bson_serializer.Timestamp,
+				DBRef:     client.bson_serializer.DBRef,
+				Binary:    client.bson_serializer.Binary,
+				Code:      client.bson_serializer.Code
+			};
+
 			client.open(next);
 		},
 		function(db, next) {


### PR DESCRIPTION
The following BSON constructors are exposed in the API:
- client.bson_serializer.Long
- client.bson_serializer.ObjectID
- client.bson_serializer.Timestamp
- client.bson_serializer.DBRef
- client.bson_serializer.Binary
- client.bson_serializer.Code

They are exposed in db.bson.XXX after connecting, e.g. db.bson.ObjectID.
