### PR TITLE
Updating variable name to fix error

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ var parseURL = function(options) {
 
 	result.username = parsed.auth && parsed.auth.split(':')[0];
 	result.password = parsed.auth && parsed.auth.split(':')[1];
-	result.db = (parsed.path || '').substr(1);
+	result.db = (parsed.pathname || '').substr(1);
 	result.host = parsed.hostname;
 	result.port = parsed.port;
 


### PR DESCRIPTION
In a dev environment when using just the database name, I was getting the error:

"Error: database name cannot be the empty string"

The result.db was being incorrectly set to parsed.path when it should be looking for parsed.pathname.
