### PR TITLE
updated default safe variable to false

### DIFF
--- a/index.js
+++ b/index.js
@@ -197,7 +197,7 @@ exports.connect = function(url, collections) {
 				rs_name:url.replSet.name
 			});
 
-			var client = new mongo.Db(url.db, replSet || new mongo.Server(url.host, url.port, {auto_reconnect:true}));
+			var client = new mongo.Db(url.db, replSet || new mongo.Server(url.host, url.port, {auto_reconnect:true}),{safe:false});
 
 			that.client = client;
 			that.bson = {


### PR DESCRIPTION
According to the mongodb people:

"Please ensure that you set the default safe variable to one of the allowed values of [true | false | {j:true} | {w:n, wtimeout:n} | {fsync:true}] the default value is false which means the driver receives does return the information of the success/error of the insert/update/remove

ex: new Db(new Server('localhost', 27017), {safe:true})

http://www.mongodb.org/display/DOCS/getLastError+Command

The default of false will change to true in the near future

This message will disappear when the default safe is set on the driver Db"
