### PR TITLE
Expose Constructors

### DIFF
--- a/index.js
+++ b/index.js
@@ -235,4 +235,6 @@ var connect = function(config, collections) {
 
 connect.connect = connect; // backwards compat
 connect.ObjectId = mongodb.ObjectID;
+connect.Cursor = Cursor;
+connect.Collection = Collection;
 module.exports = connect;


### PR DESCRIPTION
This lets users extend them if need be.

It also lets you accurately detect them with `instanceof` checks in third party code.
