### PR TITLE
Install mongodb refuses until the latest version does not specified directly

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "Ian Jorgensen <i@ge.tt>"
   ],
   "dependencies": {
-    "mongodb": "~1.2.13",
+    "mongodb": ">=1.2.8",
     "thunky": "~0.1.0",
     "readable-stream": "~1.0.2"
   },


### PR DESCRIPTION
Install mongodb refuses until the latest version does not specified directly. I don't know why.
