### PR TITLE
Add compatibility support for keyf in group command

### DIFF
--- a/index.js
+++ b/index.js
@@ -141,7 +141,7 @@ Collection.prototype.remove = function() {
 };
 
 Collection.prototype.group = function(group, callback) {
-	this._apply(DRIVER_COLLECTION_PROTO.group, [group.key, group.cond, group.initial, group.reduce, group.finalize, true, callback]);
+	this._apply(DRIVER_COLLECTION_PROTO.group, [group.key ? group.key : group.keyf, group.cond, group.initial, group.reduce, group.finalize, true, callback]);
 };
 
 forEachMethod(DRIVER_COLLECTION_PROTO, Collection.prototype, function(methodName, fn) {


### PR DESCRIPTION
Hi,
I'm new to mongojs and relatively new to mongo at all. In the mongo shell I issued a group command as documented on http://docs.mongodb.org/manual/reference/method/db.collection.group/ with a function creating the grouping key. Therefore I used the **keyf** parameter and passed in a function. Back in my node.js project I copy and pasted the group command from the mongo shell and it did not work since the **keyf** parameter is not used by mongojs. 

Since mongojs should be compatible with mongo, I created a small compatibility patch to support both **key** and **keyf**.

Cheers,
Ben
