### PR TITLE
Create Database function and add db methods to the prototype

### DIFF
--- a/index.js
+++ b/index.js
@@ -249,6 +249,17 @@ Database.prototype.collection = function(name) {
 	return this[name] = new Collection(oncollection);
 };
 
+forEachMethod(DRIVER_DB_PROTO, Database.prototype, function(methodName, fn) {
+	Database.prototype[methodName] = function() {
+		var args = arguments;
+
+		this._get(function(err, db) {
+			if (err) return getCallback(args)(err);
+			fn.apply(db, args);
+		});
+	};
+});
+
 var connect = function(config, collections) {
 	var connectionString = parseConfig(config);
 
@@ -267,17 +278,6 @@ var connect = function(config, collections) {
 	collections = collections || config.collections || [];
 	collections.forEach(function(colName) {
 		that.collection(colName);
-	});
-
-	forEachMethod(DRIVER_DB_PROTO, that, function(methodName, fn) {
-		that[methodName] = function() {
-			var args = arguments;
-
-			ondb(function(err, db) {
-				if (err) return getCallback(args)(err);
-				fn.apply(db, args);
-			});
-		};
 	});
 
 	return that;


### PR DESCRIPTION
I created a `Database` constructor function and added the database object methods to it. The other part of the code was kept in the `connect` function since I saw that the other constructor functions didn't have any other code aside from the `_get` assignment. I would like @mafintosh to give me his opinion here if he thinks that some or all of the code should be moved to the new constructor function.
