### PR TITLE
Fixing problems with collections which have the same name as functions

### DIFF
--- a/index.js
+++ b/index.js
@@ -242,7 +242,6 @@ Database.prototype.runCommand = function(opts, callback) {
 
 Database.prototype.collection = function(name) {
 	var self = this;
-	if (this[name]) return this[name];
 
 	var oncollection = thunky(function(callback) {
 		self._get(function(err, db) {
@@ -251,7 +250,7 @@ Database.prototype.collection = function(name) {
 		});
 	});
 
-	return this[name] = new Collection(oncollection);
+	return new Collection(oncollection);
 };
 
 forEachMethod(DRIVER_DB_PROTO, Database.prototype, function(methodName, fn) {
@@ -282,7 +281,7 @@ var connect = function(config, collections) {
 
 	collections = collections || config.collections || [];
 	collections.forEach(function(colName) {
-		that.collection(colName);
+		that[colName] = that.collection(colName);
 	});
 
 	return that;


### PR DESCRIPTION
If you have collection names which are identical to functions (i.e. "stats") in the mongodb-native you will get in trouble with the changes on the db prototype (https://github.com/gett/mongojs/commit/a37030ac9376d5a4f5ce514e951d0f8127c38532 and https://github.com/gett/mongojs/commit/26d17aa20f464b54e6079cc7c9826ba854e94e34).
This small fix changes the behaviour:
If you initialize collection names with the connect they will overwrite the prototype functions.
If you use the explicit collection() you will always get the collection and not the possible available prototype function.
