### PR TITLE
Expose `Database` so the prototype can be easily extended

### DIFF
--- a/index.js
+++ b/index.js
@@ -315,4 +315,5 @@ connect.connect = connect; // backwards compat
 connect.ObjectId = mongodb.ObjectID;
 connect.Cursor = Cursor;
 connect.Collection = Collection;
+connect.Database = Database;
 module.exports = connect;


### PR DESCRIPTION
This follows on from https://github.com/gett/mongojs/pull/43 where the feature was added, but at the time there wasn't a separate `Database` class to extend.
