### PR TITLE
Fix the link to the mongo native driver.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # mongojs
 
 A [node.js](http://nodejs.org) module for mongodb, that emulates [the official mongodb API](http://www.mongodb.org/display/DOCS/Home) as much as possible. 
-It wraps [mongodb-native](https://github.com/christkv/node-mongodb-native/) and is available through [npm](http://npmjs.org)
+It wraps [mongodb-native](https://github.com/mongodb/node-mongodb-native/) and is available through [npm](http://npmjs.org)
 
 	npm install mongojs
 


### PR DESCRIPTION
Shouldn't we link to the mongodb/node-mongodb-native project instead?
