### PR TITLE
Modified 'result' to 'res' to follow the example conventions used in the...

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,8 +135,8 @@ Note that you need to explicitly set the selection parameter in the `find` call.
 With mongojs you can run database commands just like with the mongo shell using `db.runCommand()` 
 
 ```js
-db.runCommand({ping:1}, function(err, result) {
-	if(!err && result.ok) console.log("we're up");
+db.runCommand({ping:1}, function(err, res) {
+	if(!err && res.ok) console.log("we're up");
 });
 ```
 


### PR DESCRIPTION
... rest of the document

All of the other examples use 3/4 letter variables for the example code.  Updating this example to follow that loose convention.
