### PR TITLE
Manage the sutdown command.

### DIFF
--- a/index.js
+++ b/index.js
@@ -255,7 +255,15 @@ Database.prototype.runCommand = function(opts, callback) {
 	}
 	this._get(function(err, db) {
 		if (err) return callback(err);
-		db.command(opts, callback);
+		// If the command in question is a shutdown, mongojs should shut down the server without crashing.
+		if (typeof opts.shutdown != 'undefined') {
+			db.command(opts, function() {
+				db.close();
+				callback.apply(this, arguments);
+			});
+		} else {
+			db.command(opts, callback);
+		}
 	});
 };
 


### PR DESCRIPTION
This manages the shutdown command so mongojs doesn't crash when it is executed. I couldn't really find a way to test this, since doing so would shutdown the mongodb daemon. Creating mock functions is a possibility but I don't know if it is worth it, being this such an uncommon use case. What do you think?
