### PR TITLE
Avoid getIndexes crash when called with no parameters.

### DIFF
--- a/index.js
+++ b/index.js
@@ -175,7 +175,7 @@ Collection.prototype.remove = function() {
 };
 
 Collection.prototype.getIndexes = function() {
-	this._apply(DRIVER_COLLECTION_PROTO.indexes, arguments);
+	this._apply(DRIVER_COLLECTION_PROTO.indexes, ensureCallback(arguments));
 };
 
 Collection.prototype.runCommand = function(cmd, opts, callback) {


### PR DESCRIPTION
I know it makes absolutely no sense to call `getIndexes()` without parameters. But is the crash a desired behavior?
