### PR TITLE
Add license field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "version": "1.0.0-beta4",
   "repository": "git://github.com/mafintosh/mongojs.git",
   "author": "Mathias Buus Madsen <mathiasbuus@gmail.com>",
+  "license": "MIT",
   "contributors": [
     "Mathias Buus Madsen <mathiasbuus@gmail.com>",
     "Ian Jorgensen",


### PR DESCRIPTION
This suppresses the warning about the missing license field.