### PR TITLE
Add check for cb undefined in createIndex

### DIFF
--- a/lib/collection.js
+++ b/lib/collection.js
@@ -183,6 +183,8 @@ Collection.prototype.dropIndex = function(index, cb) {
 Collection.prototype.createIndex = function(index, opts, cb) {
   if (typeof opts === 'function') return this.createIndex(index, {}, opts);
   if (typeof opts === 'undefined') return this.createIndex(index, {}, noop);
+  if (typeof cb === 'undefined') return this.createIndex(index, opts, noop);
+
   opts.name = indexName(index);
   opts.key = index;
   this.runCommand('createIndexes', {indexes: [opts]}, cb);


### PR DESCRIPTION
Currently if calling ensureIndex with options but without cb an error is throw in mongodb core caused by an undefined callback. This fix checks if a callback was given otherwise it reinvokes createIndex with noop callback.