### PR TITLE
Update to latest mongodb-core, fix failing tailable cursor test

### DIFF
--- a/lib/cursor.js
+++ b/lib/cursor.js
@@ -166,8 +166,8 @@ Cursor.prototype.destroy = function() {
   var self = this;
   this._get(function(err, cursor) {
     if (err) return self.emit('error', err);
-    if (!cursor.close) return;
-    cursor.close();
+    cursor.close && cursor.close();
+    cursor.kill && cursor.kill();
   });
 };
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   ],
   "dependencies": {
     "each-series": "^0.2.0",
-    "mongodb-core": "1.1.33",
+    "mongodb-core": "^1.2.2",
     "once": "^1.3.1",
     "parse-mongo-url": "^1.1.0",
     "pump": "^1.0.0",

--- a/test/test-find-tailable.js
+++ b/test/test-find-tailable.js
@@ -14,7 +14,7 @@ test('tailable find', function(t) {
         tailable: true,
         timeout: false,
         awaitData: true,
-        numberOfRetries: -1
+        numberOfRetries: Number.MAX_VALUE
       });
 
       db.tailable.insert(expected1, function(err) {


### PR DESCRIPTION
This updates to the latest mongodb-core version (busy, aren't they?)

Also fixes the failing tailable cursor test.

It seems that the `Cursor.destroy()` call was trying to call the `cursor.close()` method. In checking the mongodb-core source, it appears the correct method is `cursor.kill()`. 

For whatever reason, not calling `kill()` or `close()` seems to have left the cursor in a state such that the next running test would fail on its first query of any sort.

I'm not sure if the cursor is using a shared instance or why that is, but it might need to be addressed.