### PR TITLE
Add support for ScramSHA1

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ var db = mongojs('example.com/mydb', ['mycollection']);
 // we can also provide some credentials
 var db = mongojs('username:password@example.com/mydb', ['mycollection']);
 
+// connect using SCRAM-SHA-1 mechanism
+var db = mongojs('username:password@example.com/mydb', ['mycollection'], {authMechanism: 'ScramSHA1'});
+
 // connect now, and worry about collections later
 var db = mongojs('mydb');
 var mycollection = db.collection('mycollection');
@@ -211,7 +214,7 @@ In the above example the `hackers` collection is enabled automagically (similar 
 
 ## Passing a DB to the constructor
 
-If you have an instance of mongojs, you can pass this to the constructor and mongojs will use the 
+If you have an instance of mongojs, you can pass this to the constructor and mongojs will use the
 existing connection of that instance instead of creating a new one.
 
 ```js

--- a/index.js
+++ b/index.js
@@ -11,10 +11,11 @@ var getDbName = function(connString) {
   return config.dbName;
 };
 
-module.exports = function(connString, cols) {
+module.exports = function(connString, cols, options) {
   var dbname = getDbName(connString);
+  if (!options) options = {};
   var onserver = thunky(function(cb) {
-    getTopology(connString, function(err, topology) {
+    getTopology(connString, options, function(err, topology) {
       if (err) return cb(err);
       cb(null, topology);
     });

--- a/lib/get-topology.js
+++ b/lib/get-topology.js
@@ -4,12 +4,23 @@ var mongodb = require('mongodb-core');
 
 var Server = mongodb.Server;
 var ReplSet = mongodb.ReplSet;
-var MongoCR = mongodb.MongoCR;
+var auth_mechs = {
+  MongoCR: mongodb.MongoCR,
+  ScramSHA1: require('mongodb-core/lib/auth/scram')
+};
 
-module.exports = function(connString, cb) {
+module.exports = function(connString, options, cb) {
   cb = once(cb);
   var config = parse(connString);
   var srv;
+
+  var authMechanism = 'MongoCR'; // Default to MongoCR
+  if (options.authMechanism) {
+    if (!auth_mechs[options.authMechanism]) {
+      return cb(new Error(options.authMechanism + ' is not a supported authentication mechanism'));
+    }
+    authMechanism = options.authMechanism;
+  }
 
   if (config.servers.length === 1) {
     var opts = config.server_options;
@@ -27,9 +38,9 @@ module.exports = function(connString, cb) {
   }
 
   if (config.auth) {
-    srv.addAuthProvider('mongocr', new MongoCR());
+    srv.addAuthProvider(authMechanism, new auth_mechs[authMechanism]());
     srv.on('connect', function(server) {
-      server.auth('mongocr', config.dbName, config.auth.user, config.auth.password, function(err, r) {
+      server.auth(authMechanism, config.dbName, config.auth.user, config.auth.password, function(err, r) {
         if (err) return cb(err);
         cb(null, r);
       });


### PR DESCRIPTION
Add support to connect using different authentication mechanisms with a new options argument. 
Fixes: https://github.com/mafintosh/mongojs/issues/208

A PR has also been made to prevent having to requiring in ScramSHA1. 
https://github.com/christkv/mongodb-core/pull/28