### PR TITLE
Add upsert() method for Bulk.find

### DIFF
--- a/lib/bulk.js
+++ b/lib/bulk.js
@@ -12,14 +12,9 @@ var Bulk = function(colName, ordered, onserver, dbname) {
   this._dbname = dbname;
 
   var self = this;
-  var upsert = false;
-  this.upsert = function(){
-    upsert = true;
-    return self;
-  };
   this.find = function(query) {
+    var upsert = false;
     var findobj = {};
-
     var remove = function(lim) {
       if (!self._currCmd) {
         self._currCmd = {
@@ -62,6 +57,10 @@ var Bulk = function(colName, ordered, onserver, dbname) {
       self._currCmd.updates.push({q: query, u: updObj, multi: multi, upsert: upsert});
     };
 
+    findobj.upsert = function(){
+      upsert = true;
+      return findobj;
+    };
     findobj.remove = function() {
       remove(0);
     };

--- a/lib/bulk.js
+++ b/lib/bulk.js
@@ -12,6 +12,11 @@ var Bulk = function(colName, ordered, onserver, dbname) {
   this._dbname = dbname;
 
   var self = this;
+  var upsert = false;
+  this.upsert = function(){
+    upsert = true;
+    return self;
+  };
   this.find = function(query) {
     var findobj = {};
 
@@ -54,7 +59,7 @@ var Bulk = function(colName, ordered, onserver, dbname) {
           writeConcern: {w: 1}
         };
       }
-      self._currCmd.updates.push({q: query, u: updObj, multi: multi, upsert: false});
+      self._currCmd.updates.push({q: query, u: updObj, multi: multi, upsert: upsert});
     };
 
     findobj.remove = function() {


### PR DESCRIPTION
Add upsert() method for Bulk.find to allow the insertion of new documents when there are no matches with the update and updateOne methods.