### PR TITLE
Add upsert() method for Bulk.find

### DIFF
--- a/lib/bulk.js
+++ b/lib/bulk.js
@@ -13,8 +13,8 @@ var Bulk = function(colName, ordered, onserver, dbname) {
 
   var self = this;
   this.find = function(query) {
+    var upsert = false;
     var findobj = {};
-
     var remove = function(lim) {
       if (!self._currCmd) {
         self._currCmd = {
@@ -54,7 +54,11 @@ var Bulk = function(colName, ordered, onserver, dbname) {
           writeConcern: {w: 1}
         };
       }
-      self._currCmd.updates.push({q: query, u: updObj, multi: multi, upsert: false});
+      self._currCmd.updates.push({q: query, u: updObj, multi: multi, upsert: upsert});
+    };
+
+    findobj.upsert = function(){
+      return upsert = true, findobj;
     };
 
     findobj.remove = function() {

--- a/test/test-bulk-updates.js
+++ b/test/test-bulk-updates.js
@@ -23,17 +23,23 @@ insert('bulk', [{
     bulk.find({type: 'fire'}).remove();
     bulk.find({type: 'water'}).updateOne({$set: {hp: 100}});
 
+    bulk.find({name: 'Squirtle'}).upsert().updateOne({$set : {name: 'Wartortle', type: 'water'}});
+    bulk.find({name: 'Bulbasaur'}).upsert().updateOne({$setOnInsert: {name: "Bulbasaur"}, $set: {type: 'grass', level: 1}});
+
     bulk.execute(function(err, res) {
       t.ok(res.ok);
       db.a.find(function(err, res) {
-        t.equal(res[0].name, 'Squirtle');
+        t.equal(res[0].name, 'Wartortle');
         t.equal(res[1].name, 'Starmie');
         t.equal(res[2].name, 'Lapras');
         t.equal(res[3].name, 'Pidgeotto');
+        t.equal(res[4].name, 'Bulbasaur');
+        t.equal(res[4].type, 'grass');
 
         t.equal(res[0].level, 3);
         t.equal(res[1].level, 3);
         t.equal(res[2].level, 3);
+        t.equal(res[4].level, 1);
 
         t.equal(res[0].hp, 100);
         t.end();


### PR DESCRIPTION
Add upsert() method for Bulk.find to allow the insertion of new documents when there are no matches with the update and updateOne methods.