### PR TITLE
Upgrade dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,9 +27,9 @@
     "Thomas Watson Steen <w@tson.dk> https://twitter.com/wa7son"
   ],
   "dependencies": {
-    "each-series": "^0.2.0",
-    "mongodb-core": "^1.2.2",
-    "once": "^1.3.1",
+    "each-series": "^1.0.0",
+    "mongodb-core": "^1.2.8",
+    "once": "^1.3.2",
     "parse-mongo-url": "^1.1.0",
     "pump": "^1.0.0",
     "readable-stream": "^2.0.2",


### PR DESCRIPTION
I just did a little house-keeping with the dependencies. I've already [upgraded the dev-dependencies](https://github.com/mafintosh/mongojs/commit/a0caa82b57142c7cc365e9df3b9a5f1718a53e2d), but thought I'd just make this into a PR as it bumps a major version of a "prod" dependency.

The following 3 dependencies have been changes:

- `mongodb-core` from `^1.2.2` to `^1.2.8`
- `each-series` from `^0.2.0` to `^1.0.0`
- `once` from `^1.3.1` to `^1.3.2`

Only `each-series` by @sorribas is a major upgrade, but according to [the commits](https://github.com/sorribas/each-series/commits/master) there should be nothing to worry about.