### PR TITLE
Add listCollections function

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,6 +342,8 @@ Get the name of the collection.
 
 #####`db.getCollectionNames(callback)`
 
+#####`db.listCollections(callback)`
+
 #####`db.getLastError(callback)`
 
 #####`db.getLastErrorObj(callback)`

--- a/lib/database.js
+++ b/lib/database.js
@@ -66,6 +66,15 @@ Database.prototype.getCollectionNames = function (cb) {
   })
 }
 
+Database.prototype.listCollections = function (cb) {
+  this.runCommand('listCollections', function (err, res) {
+    if (err) return cb(err)
+    cb(null, res.cursor.firstBatch.map(function (col) {
+      return col.name
+    }))
+  })
+}
+
 Database.prototype.createCollection = function (name, opts, cb) {
   if (typeof opts === 'function') return this.createCollection(name, {}, opts)
 

--- a/test/test-list-collections.js
+++ b/test/test-list-collections.js
@@ -1,0 +1,15 @@
+var insert = require('./insert')
+
+insert('listCollections', [{
+  hello: 'world'
+}], function (db, t, done) {
+  db.collection('b').save({hello: 'world'}, function (err, b) {
+    t.error(err)
+    db.listCollections(function (err, colNames) {
+      t.error(err)
+      t.notEqual(colNames.indexOf('a'), -1)
+      t.notEqual(colNames.indexOf('b'), -1)
+      done()
+    })
+  })
+})


### PR DESCRIPTION
Using `<database>.system.namespaces` is going to [deprecated since 3.0](http://docs.mongodb.org/manual/reference/system-collections/).
So we can use command `{listCollections: 1}` to get collection names in current database.