### PR TITLE
Add authSource for SCRAM-SHA-1

### DIFF
--- a/lib/get-topology.js
+++ b/lib/get-topology.js
@@ -42,7 +42,8 @@ module.exports = function (connString, options, cb) {
   if (config.auth) {
     srv.addAuthProvider(authMechanism, new authMechanisms[authMechanism]())
     srv.on('connect', function (server) {
-      server.auth(authMechanism, config.dbName, config.auth.user, config.auth.password, function (err, r) {
+      var authSource = options.authSource || config.dbName;
+      server.auth(authMechanism, authSource, config.auth.user, config.auth.password, function (err, r) {
         if (err) return cb(err)
         cb(null, r)
       })

--- a/lib/get-topology.js
+++ b/lib/get-topology.js
@@ -42,7 +42,7 @@ module.exports = function (connString, options, cb) {
   if (config.auth) {
     srv.addAuthProvider(authMechanism, new authMechanisms[authMechanism]())
     srv.on('connect', function (server) {
-      var authSource = options.authSource || config.dbName;
+      var authSource = options.authSource || config.dbName
       server.auth(authMechanism, authSource, config.auth.user, config.auth.password, function (err, r) {
         if (err) return cb(err)
         cb(null, r)


### PR DESCRIPTION
This is just a quick fix to support adding authSource for authentication and doesn't take into account any caveats for other authentication schemas (which I don't know much about).

If authSource is not specified, the dbname is assumed as the authentication source database.

An alternative is to specify authSource as a query parameter and insert as needed.