### PR TITLE
Fixed insert error detection and passing

### DIFF
--- a/lib/collection.js
+++ b/lib/collection.js
@@ -83,7 +83,7 @@ Collection.prototype.insert = function (docOrDocs, cb) {
     }
     server.insert(self._fullColName(), docs, writeOpts, function (err, res) {
       if (err) return cb(err)
-      if (res.result.writeErrors && res.result.writeErrors.length > 0) return cb(res.result.writeErrors[0])
+      if (res && res.result && res.result.writeErrors && res.result.writeErrors.length > 0) return cb(res.result.writeErrors[0])
       cb(null, docOrDocs)
     })
   })

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -81,8 +81,9 @@ Collection.prototype.insert = function (docOrDocs, cb) {
     for (var i = 0; i < docs.length; i++) {
       if (!docs[i]._id) docs[i]._id = oid()
     }
-    server.insert(self._fullColName(), docs, writeOpts, function (err) {
+    server.insert(self._fullColName(), docs, writeOpts, function (err, res) {
       if (err) return cb(err)
+      if (res.result.writeErrors && res.result.writeErrors.length > 0) return cb(res.result.writeErrors[0])
       cb(null, docOrDocs)
     })
   })


### PR DESCRIPTION
mongodb-core doesn't pass an error object in certain cases, such as on duplicate key errors.  This change checks the result's `writeErrors` property and, if it's populated, passes the first error back.

This should fix #235 and #197.