### PR TITLE
Allow writeConcern and ordered to be passed in the options parameter of Collection insert, update, save, remove

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,7 +278,7 @@ Apply a query and get one single document passed as a callback. The callback rec
 
 #####`db.collection.group(document, callback)`
 
-#####`db.collection.insert(docOrDocs, [callback])`
+#####`db.collection.insert(docOrDocs, [options], [callback])`
 
 #####`db.collection.isCapped(callback)`
 
@@ -286,11 +286,11 @@ Apply a query and get one single document passed as a callback. The callback rec
 
 #####`db.collection.reIndex([callback])`
 
-#####`db.collection.remove(query, [justOne], [callback])`
+#####`db.collection.remove(query, [options], [callback])`
 
 #####`db.collection.runCommand(command, [callback])`
 
-#####`db.collection.save(doc, [callback])`
+#####`db.collection.save(doc, [options], [callback])`
 
 #####`db.collection.stats(callback)`
 

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -4,7 +4,6 @@ var Cursor = require('./cursor')
 var AggregationCursor = require('./aggregation-cursor')
 var Bulk = require('./bulk')
 
-var writeOpts = {writeConcern: {w: 1}, ordered: true}
 var noop = function () {}
 var oid = mongodb.BSON.ObjectID.createPk
 var Code = mongodb.BSON.Code
@@ -13,6 +12,19 @@ var indexName = function (index) {
   return Object.keys(index).map(function (key) {
     return key + '_' + index[key]
   }).join('_')
+}
+
+var pullWriteOpts = function (opts) {
+  var writeOpts = {writeConcern: {w: 1}, ordered: true}
+  if ('writeConcern' in opts) {
+    writeOpts.writeConcern = opts.writeConcern
+    delete opts.writeConcern
+  }
+  if ('ordered' in opts) {
+    writeOpts.ordered = opts.ordered
+    delete opts.ordered
+  }
+  return writeOpts
 }
 
 var Collection = function (opts, getServer) {
@@ -71,7 +83,10 @@ Collection.prototype.distinct = function (field, query, cb) {
   })
 }
 
-Collection.prototype.insert = function (docOrDocs, cb) {
+Collection.prototype.insert = function (docOrDocs, opts, cb) {
+  if (!opts && !cb) return this.update(docOrDocs, {}, noop)
+  if (typeof opts === 'function') return this.insert(docOrDocs, {}, opts)
+
   cb = cb || noop
   var self = this
   this._getServer(function (err, server) {
@@ -81,6 +96,8 @@ Collection.prototype.insert = function (docOrDocs, cb) {
     for (var i = 0; i < docs.length; i++) {
       if (!docs[i]._id) docs[i]._id = oid()
     }
+
+    var writeOpts = pullWriteOpts(opts)
     server.insert(self._fullColName(), docs, writeOpts, function (err) {
       if (err) return cb(err)
       cb(null, docOrDocs)
@@ -97,6 +114,7 @@ Collection.prototype.update = function (query, update, opts, cb) {
   this._getServer(function (err, server) {
     if (err) return cb(err)
 
+    var writeOpts = pullWriteOpts(opts)
     opts.q = query
     opts.u = update
     server.update(self._fullColName(), [opts], writeOpts, function (err, res) {
@@ -106,26 +124,37 @@ Collection.prototype.update = function (query, update, opts, cb) {
   })
 }
 
-Collection.prototype.save = function (doc, cb) {
+Collection.prototype.save = function (doc, opts, cb) {
+  if (!opts && !cb) return this.save(doc, {}, noop)
+  if (typeof opts === 'function') return this.save(doc, {}, opts)
+
   cb = cb || noop
   if (doc._id) {
-    this.update({_id: doc._id}, doc, {upsert: true}, function (err) {
+    opts.upsert = true
+    this.update({_id: doc._id}, doc, opts, function (err) {
       if (err) return cb(err)
       cb(null, doc)
     })
   } else {
-    this.insert(doc, cb)
+    this.insert(doc, opts, cb)
   }
 }
 
-Collection.prototype.remove = function (query, justOne, cb) {
+Collection.prototype.remove = function (query, opts, cb) {
+  if (!opts && !query && !cb) return this.remove({}, false, noop)
   if (typeof query === 'function') return this.remove({}, false, query)
-  if (typeof justOne === 'function') return this.remove(query, false, justOne)
+  if (typeof opts === 'function') return this.remove(query, false, opts)
 
   var self = this
   this._getServer(function (err, server) {
     if (err) return cb(err)
-    server.remove(self._fullColName(), [{q: query, limit: justOne ? 1 : 0}], writeOpts, function (err, res) {
+
+    if (typeof opts !== 'object') {
+      opts = {limit: opts ? 1 : 0}
+    }
+    var writeOpts = pullWriteOpts(opts)
+    opts.q = query
+    server.remove(self._fullColName(), [opts], writeOpts, function (err, res) {
       if (err) return cb(err)
       cb(null, res.result)
     })

--- a/test/test-insert.js
+++ b/test/test-insert.js
@@ -21,8 +21,16 @@ test('insert', function (t) {
         t.error(err)
         t.equal(docs[0].name, 'Pidgeotto')
         t.equal(docs.length, 1)
-        db.a.remove(function () {
-          db.close(t.end.bind(t))
+
+        // It should allow write options to be passed as
+        // the second parameter
+        db.a.insert({name: 'Metapod'}, {writeConcern: {w: 1}, ordered: true}, function (err, doc) {
+          t.error(err)
+          t.equal(doc.name, 'Metapod')
+
+          db.a.remove(function () {
+            db.close(t.end.bind(t))
+          })
         })
       })
     })

--- a/test/test-remove.js
+++ b/test/test-remove.js
@@ -7,6 +7,8 @@ insert('remove', [{
   name: 'Starmie', type: 'water'
 }, {
   name: 'Lapras', type: 'water'
+}, {
+  name: 'psyduck', type: 'water'
 }], function (db, t, done) {
   // Remove just one
   db.a.remove({type: 'water'}, true, function (err, lastErrorObject) {
@@ -15,18 +17,30 @@ insert('remove', [{
 
     db.a.find({type: 'water'}, function (err, docs) {
       t.error(err)
-      t.equal(docs.length, 2)
+      t.equal(docs.length, 3)
       t.equal(docs[0].name, 'Starmie')
 
-      // Normal remove
-      db.a.remove({type: 'water'}, function (err, lastErrorObject) {
+      // remove one using object opts format
+      db.a.remove({type: 'water'}, {limit: 1, writeConcern: {w: 1}, ordered: false}, function (err, lastErrorObject) {
         t.error(err)
-        t.equal(lastErrorObject.n, 2)
+        t.equal(lastErrorObject.n, 1)
 
         db.a.find({type: 'water'}, function (err, docs) {
           t.error(err)
-          t.equal(docs.length, 0)
-          done()
+          t.equal(docs.length, 2)
+          t.equal(docs[0].name, 'Lapras')
+
+          // Normal remove
+          db.a.remove({type: 'water'}, function (err, lastErrorObject) {
+            t.error(err)
+            t.equal(lastErrorObject.n, 2)
+
+            db.a.find({type: 'water'}, function (err, docs) {
+              t.error(err)
+              t.equal(docs.length, 0)
+              done()
+            })
+          })
         })
       })
     })

--- a/test/test-save.js
+++ b/test/test-save.js
@@ -13,8 +13,15 @@ test('save', function (t) {
       t.error(err)
       t.ok(doc._id)
       t.equal(doc.hello, 'verden')
-      db.a.remove(function () {
-        db.close(t.end.bind(t))
+
+      doc.hello = 'sf'
+      db.a.save(doc, {writeConcern: {w: 1}, ordered: true}, function (err, doc) {
+        t.error(err)
+        t.ok(doc._id)
+        t.equal(doc.hello, 'sf')
+        db.a.remove(function () {
+          db.close(t.end.bind(t))
+        })
       })
     })
   })

--- a/test/test-update.js
+++ b/test/test-update.js
@@ -10,7 +10,17 @@ insert('update', [{
     db.a.findOne(function (err, doc) {
       t.error(err)
       t.equal(doc.hello, 'verden')
-      done()
+
+      db.a.update({hello: 'verden'}, {$set: {hello: 'sf'}}, {writeConcern: {w: 1}, ordered: true}, function (err, lastErrorObject) {
+        t.error(err)
+        t.equal(lastErrorObject.n, 1)
+
+        db.a.findOne(function (err, doc) {
+          t.error(err)
+          t.equal(doc.hello, 'sf')
+          done()
+        })
+      })
     })
   })
 })


### PR DESCRIPTION
Mongo allows the insert, update, remove, and save operations to pass writeConcern as an option. It would be nice for mongojs to allow this as well, instead of hardcoding the default write options.

http://docs.mongodb.org/manual/reference/write-concern/
http://docs.mongodb.org/manual/reference/method/db.collection.insert/
http://docs.mongodb.org/manual/reference/method/db.collection.update/
http://docs.mongodb.org/manual/reference/method/db.collection.remove/
http://docs.mongodb.org/manual/reference/method/db.collection.save/