### PR TITLE
Expose bson stuff visible in the shell

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,4 +19,10 @@ module.exports = function (connString, cols, options) {
   return db
 }
 
+// expose bson stuff visible in the shell
 module.exports.ObjectId = bson.ObjectId
+module.exports.DBRef = bson.DBRef
+module.exports.Timestamp = bson.Timestamp
+module.exports.MinKey = bson.MinKey
+module.exports.MaxKey = bson.MaxKey
+module.exports.NumberLong = bson.Long


### PR DESCRIPTION
Previusly only the `ObjectId` function was exposed and available directly from the root of the `mongojs` module.

This commit exposes a couple of other BSON types in the same manner. This is now the full list of exposed types:

- `mongojs.ObjectId`
- `mongojs.DBRef`
- `mongojs.Timestamp`
- `mongojs.MinKey`
- `mongojs.MaxKey`
- `mongojs.NumberLong` (the BSON type `Long`)

This is actually a revival commit, bringing back the spirit of the very first Pull Request ever made to this projeect back in 2011 (later refined in commit 06bbf02): #1