### PR TITLE
Add noop callback in collection.remove()

### DIFF
--- a/lib/collection.js
+++ b/lib/collection.js
@@ -122,6 +122,7 @@ Collection.prototype.save = function (doc, cb) {
 Collection.prototype.remove = function (query, justOne, cb) {
   if (typeof query === 'function') return this.remove({}, false, query)
   if (typeof justOne === 'function') return this.remove(query, false, justOne)
+  cb = cb || noop
 
   var self = this
   this._getServer(function (err, server) {


### PR DESCRIPTION
Hi guys,

I was using the .remove method in my collection, but I didn't care or need about the result (cb), so I executed:
```javascript
db.mycollection.remove({foo:"bar"});
```

and got the following error:

```
TypeError: cb is not a function
    at ./node_modules/mongojs/lib/collection.js:131:7
```

Checking the code, I noticed that the remove() method has no noop fallback.
I just added one.
I did not add a test because I saw that no tests are currently testing cases where callbacks are not provided.

regards!
