### PR TITLE
Bulk execute function returns success callback if there are no commands to execute

### DIFF
--- a/lib/bulk.js
+++ b/lib/bulk.js
@@ -146,6 +146,11 @@ Bulk.prototype.execute = function (cb) {
     upserted: [ ]
   }
 
+  if (!this._currCmd && this._cmds.length < 1) {
+    result.ok = 1
+    return cb(null, result)
+  }
+
   this._cmds.push(this._currCmd)
   this._getConnection(function (err, connection) {
     if (err) return cb(err)


### PR DESCRIPTION
With this update we will be able to execute bulk and get success even if there are no commands to execute. 
Right now in such situation callback is throwing an error: "Error: query must be specified for query".
Resolve #184.

The following code will success:
var bulk = db.collection('collection').initializeUnorderedBulkOp()
bulk.execute(callback)