### PR TITLE
Fix handling default arguments in ensureIndex

### DIFF
--- a/lib/collection.js
+++ b/lib/collection.js
@@ -200,9 +200,9 @@ Collection.prototype.createIndex = function (index, opts, cb) {
 }
 
 Collection.prototype.ensureIndex = function (index, opts, cb) {
-  if (typeof opts === 'function') return this.createIndex(index, {}, opts)
-  if (typeof opts === 'undefined') return this.createIndex(index, {}, noop)
-  if (typeof cb === 'undefined') return this.createIndex(index, opts, noop)
+  if (typeof opts === 'function') return this.ensureIndex(index, {}, opts)
+  if (typeof opts === 'undefined') return this.ensureIndex(index, {}, noop)
+  if (typeof cb === 'undefined') return this.ensureIndex(index, opts, noop)
 
   this._getCollection(function (err, collection) {
     if (err) return cb(err)


### PR DESCRIPTION
I don't think it should be calling createIndex.