### PR TITLE
Wrapper to rename a collection

### DIFF
--- a/lib/collection.js
+++ b/lib/collection.js
@@ -141,6 +141,16 @@ Collection.prototype.remove = function (query, opts, cb) {
   })
 }
 
+Collection.prototype.rename = function (name, opts, cb) {
+  if (typeof opts === 'undefined') return this.rename(index, {}, noop)
+  if (typeof cb === 'undefined') return this.rename(name, noop)
+
+  this._getCollection(function (err, collection) {
+    if (err) return cb(err)
+    collection.rename(name, opts, cb)
+  })
+}
+
 Collection.prototype.drop = function (cb) {
   this.runCommand('drop', cb)
 }

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -142,7 +142,7 @@ Collection.prototype.remove = function (query, opts, cb) {
 }
 
 Collection.prototype.rename = function (name, opts, cb) {
-  if (typeof opts === 'undefined') return this.rename(index, {}, noop)
+  if (typeof opts === 'undefined') return this.rename(name, {}, noop)
   if (typeof cb === 'undefined') return this.rename(name, noop)
 
   this._getCollection(function (err, collection) {


### PR DESCRIPTION
Added wrapper around the [rename](http://mongodb.github.io/node-mongodb-native/api-generated/collection.html#rename) command to rename a collection.
