### PR TITLE
Run tests with tap-spec

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "xtend": "^4.0.0"
   },
   "scripts": {
-    "test": "standard && tape test/test-*.js && node --harmony --harmony-proxies node_modules/tape/bin/tape test/test-*.js",
+    "test": "standard && (tape test/test-*.js && node --harmony --harmony-proxies node_modules/tape/bin/tape test/test-*.js) | tap-spec",
     "cover": "node --harmony --harmony-proxies node_modules/istanbul/lib/cli.js cover node_modules/tape/bin/tape test/test-*.js --report html",
     "geotag": "geopkg update"
   },
@@ -47,6 +47,7 @@
     "istanbul": "^0.4.1",
     "shelljs": "^0.5.3",
     "standard": "^5.4.1",
+    "tap-spec": "^4.1.1",
     "tape": "^4.0.1"
   },
   "coordinates": [


### PR DESCRIPTION
@watson @mafintosh This branch is using tap-spec to run tests which gives a much nicer output and a  neat summary how many tests passed/failed. OK to merge?