### PR TITLE
bulk divide into actions, closes #265

### DIFF
--- a/lib/bulk.js
+++ b/lib/bulk.js
@@ -169,7 +169,7 @@ function getCmdsBrokenIntoChunks (cmds, chunkSize) {
     }
   })
 
-  return [].concat.apply([], result) //flatten
+  return [].concat.apply([], result) // flatten
 }
 
 Bulk.prototype.execute = function (cb) {

--- a/lib/bulk.js
+++ b/lib/bulk.js
@@ -3,6 +3,7 @@ var each = require('each-series')
 
 var noop = function () {}
 var oid = mongodb.ObjectID.createPk
+const BulkChunkSize = 1000
 
 var Bulk = function (colName, ordered, onserver) {
   this._colname = colName
@@ -141,6 +142,36 @@ Bulk.prototype.toString = function () {
   return JSON.stringify(this.tojson())
 }
 
+function getCmdsBrokenIntoChunks (cmds, chunkSize) {
+  var result = cmds.map(function (cmd) {
+    var cmdKey
+    if (cmd.update) {
+      cmdKey = 'updates'
+    } else if (cmd.insert) {
+      cmdKey = 'documents'
+    } else if (cmd.delete) {
+      cmdKey = 'deletes'
+    }
+    if (cmd[cmdKey].length > chunkSize) {
+      var all = cmd[cmdKey]
+      delete cmd[cmdKey]
+      var result = []
+
+      for (var i = 0; i < all.length; i += chunkSize) {
+        var newCmd = JSON.parse(JSON.stringify(cmd)) // deep copy
+        newCmd[cmdKey] = all.slice(i, chunkSize + i)
+        result.push(newCmd)
+      }
+
+      return result
+    } else {
+      return cmd
+    }
+  })
+
+  return [].concat.apply([], result) //flatten
+}
+
 Bulk.prototype.execute = function (cb) {
   if (!cb) return this.execute(noop)
 
@@ -162,7 +193,7 @@ Bulk.prototype.execute = function (cb) {
 
   this._getConnection(function (err, connection) {
     if (err) return cb(err)
-    each(self._cmds, function (cmd, i, done) {
+    each(getCmdsBrokenIntoChunks(self._cmds, BulkChunkSize), function (cmd, i, done) {
       connection.command(cmd, function (err, res) {
         if (err) return done(err)
         result[cmdkeys[Object.keys(cmd)[0]]] += res.n

--- a/test/test-bulk-big-execute.js
+++ b/test/test-bulk-big-execute.js
@@ -1,0 +1,26 @@
+var insert = require('./insert')
+
+insert('bulk', [{
+  name: 'Squirtle', type: 'water'
+}], function (db, t, done) {
+  db.runCommand('serverStatus', function (err, resp) {
+    t.error(err)
+    if (parseFloat(resp.version) < 2.6) return t.end()
+
+    var bulk = db.a.initializeOrderedBulkOp()
+    var numberOfOp = 1066
+    for (var i = 0; i < numberOfOp; ++i) {
+      bulk.insert({name: 'Spearow', type: 'flying'})
+    }
+
+    bulk.execute(function (err, res) {
+      t.error(err)
+      t.ok(res.ok)
+      db.a.find(function (err, res) {
+        t.error(err)
+        t.equal(res.length, numberOfOp + 1) // +1 because we inserted one doc before test
+        t.end()
+      })
+    })
+  })
+})

--- a/test/test-cursor-map.js
+++ b/test/test-cursor-map.js
@@ -10,8 +10,9 @@ insert('cursor.map', [{
     return x.hello
   }, function (err, res) {
     t.error(err)
-    t.equal(res[0], 'world1')
-    t.equal(res[1], 'world2')
+    t.equal(res.length, 2)
+    t.notEqual(res.indexOf('world1'), -1)
+    t.notEqual(res.indexOf('world2'), -1)
     done()
   })
 })


### PR DESCRIPTION
This is manual fix for issue #265

If group of bulk operations have more than 1000 operations, it divides the group into smaller groups of 1000 or less. 

This work-around needs to be removed when it will be implemented in mongodb driver.
