### PR TITLE
Updated readme with connection options example

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ var db = mongojs('username:password@example.com/mydb?authMechanism=SCRAM-SHA-1',
 // connect using a different auth source
 var db = mongojs('username:password@example.com/mydb?authSource=authdb', ['mycollection'])
 
+// connect with options
+var db = mongojs('username:password@example.com/mydb', ['mycollection'], { ssl: true })
+
 // connect now, and worry about collections later
 var db = mongojs('mydb')
 var mycollection = db.collection('mycollection')


### PR DESCRIPTION
I needed to use connection options, but didn't see an example in the readme. I guessed that they'd be after the connection string, but that was incorrect. To save others the trouble, I added an example to the readme.