### PR TITLE
Fix for node 6

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ module.exports = function (connString, cols, options) {
         return db[prop]
       }
     }
-    var p = Proxy.create == undefined ? new Proxy({}, handler) : Proxy.create(handler);
+    var p = Proxy.create === undefined ? new Proxy({}, handler) : Proxy.create(handler);
     return p
   }
 

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ var mongodb = require('mongodb')
 module.exports = function (connString, cols, options) {
   var db = new Database(connString, cols, options)
   if (typeof Proxy !== 'undefined') {
-    var p = Proxy.create({
+    var handler = {
       get: function (obj, prop) {
         // Work around for event emitters to work together with harmony proxy
         if (prop === 'on' || prop === 'emit') {
@@ -15,8 +15,8 @@ module.exports = function (connString, cols, options) {
         db[prop] = db.collection(prop)
         return db[prop]
       }
-    })
-
+    }
+    var p = Proxy.create == undefined ? new Proxy({}, handler) : Proxy.create(handler);
     return p
   }
 

--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ module.exports = function (connString, cols, options) {
         return db[prop]
       }
     }
-    var p = Proxy.create === undefined ? new Proxy({}, handler) : Proxy.create(handler);
+    var p = Proxy.create === undefined ? new Proxy({}, handler) : Proxy.create(handler)
     return p
   }
 


### PR DESCRIPTION
This fix adds compatibility for node 6. Works with node 6 (uses `new Proxy`), node 5 (uses no Proxy), and node 5 with the `--harmony-proxies` flag (uses `Proxy.create`) and I didn't spot any obvious errors.
