### PR TITLE
Adds support for ES6 default module import syntax

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,3 +36,6 @@ module.exports.ObjectID = mongodb.ObjectID
 module.exports.ObjectId = mongodb.ObjectId
 module.exports.Symbol = mongodb.Symbol
 module.exports.Timestamp = mongodb.Timestamp
+
+// Add support for default ES6 module imports
+module.exports.default = module.exports


### PR DESCRIPTION
Hello there, I used the technique from [node-fetch](https://github.com/bitinn/node-fetch/blob/master/index.js#L23) to allow using `import mongojs from "mongojs"` with this library :1st_place_medal: 