### PR TITLE
update mongodb-native detection

### DIFF
--- a/lib/database.js
+++ b/lib/database.js
@@ -40,7 +40,11 @@ var Database = function (connString, cols, options) {
     this._dbname = connString._dbname
     this._getConnection = connString._getConnection
   } else { // try mongodb-native
-    this._dbname = parse(connString.options.url).dbName
+    if (typeof connString.databaseName === 'string') {
+      this._dbname = connString.databaseName
+    } else {
+      this._dbname = parse(connString.options.url).dbName
+    }
 
     this._getConnection = thunky(function (cb) {
       cb(null, connString)

--- a/test/test-connect-mongodb-native.js
+++ b/test/test-connect-mongodb-native.js
@@ -1,0 +1,12 @@
+var test = require('tape')
+var mongodb = require('mongodb')
+var mongojs = require('../')
+
+test('connect native mongodb', function (t) {
+  mongodb('mongodb://localhost/test', function (err, nativeDB) {
+    t.equal(err, null)
+    var db = mongojs(nativeDB, ['a'])
+    t.equal(db._dbname, 'test')
+    t.end()
+  })
+})


### PR DESCRIPTION
Newer versions of mongo native driver don't store the database name the same way.

Update the detection in `database.js` to support handling newer native objects.