### PR TITLE
Work around for property 'Symbol(Symbol.toPrimitive)' in Proxy

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,6 +12,9 @@ module.exports = function (connString, cols, options) {
         }
 
         if (db[prop]) return db[prop]
+        // Work around for property 'Symbol(Symbol.toPrimitive)' with node v6.x or higher version
+        if (typeof prop === "symbol") return db[prop]
+        
         db[prop] = db.collection(prop)
         return db[prop]
       }


### PR DESCRIPTION
When I am trying to migrate to higher version nodeJS, e.g. 6.9.1. I found below error coming from Proxy handler, which is caused by `Symbol` property. So I add another workaround to skip `Symbol` property during Proxy's get handler
```
TypeError: '[object Object]' returned for property 'Symbol(Symbol.toPrimitive)' of object '[object Object]' is not a function
    at exports.format (util.js:108:18)
    at Console.log (console.js:43:37)
    at Database.<anonymous> (C:\git\test\app2.js:33:13)
    at emitNone (events.js:86:13)
    at Database.emit (events.js:185:7)
    at C:\git\test\node_modules\mongojs\lib\database.js:35:14
    at connectCallback (C:\git\test\node_modules\mongodb\lib\mongo_client.js:426:5)
    at C:\git\test\node_modules\mongodb\lib\mongo_client.js:364:13
    at _combinedTickCallback (internal/process/next_tick.js:67:7)
    at process._tickCallback (internal/process/next_tick.js:98:9)
```